### PR TITLE
fix build error with cmake target dependencies:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,6 @@ target_compile_options(${PROJECT_NAME}
 		-Wno-missing-braces
 )
 
-# download cppVulkanAPI
-add_custom_target(
-	download_cppVulkanAPI
-	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/download_cppVulkanAPI.sh
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-add_dependencies(${PROJECT_NAME} download_cppVulkanAPI)
-
 target_sources(${PROJECT_NAME}
 	PRIVATE
 		src/main.cpp

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Sript to build the project
+
+# Download the necessary external libraries
+./scripts/download_cppVulkanAPI.sh
+
+# create build directory
+mkdir -p build
+
+# build the project
+cd build
+cmake ..
+make -j

--- a/scripts/download_cppVulkanAPI.sh
+++ b/scripts/download_cppVulkanAPI.sh
@@ -4,6 +4,5 @@ if [ ! -d external/cppVulkanAPI ]
 then
 	echo "cloning 'git@github.com:SaumonDesMers/cppVulkanAPI.git' in external/cppVulkanAPI"
 
-	mkdir -p external/glm
 	git clone git@github.com:SaumonDesMers/cppVulkanAPI.git external/cppVulkanAPI
 fi


### PR DESCRIPTION
Cmake depended on cppVulkanAPI before it was cloned so I added build.sh to build the project
Build.sh now handle cppVulkanAPI cloning, as well as creating the build directory and executing cmake and make